### PR TITLE
Add method for DELETE users/:id

### DIFF
--- a/lib/oktakit/client/users.rb
+++ b/lib/oktakit/client/users.rb
@@ -195,6 +195,22 @@ module Oktakit
         post("/users/#{id}/lifecycle/unlock", options)
       end
 
+      # Delete User
+      #
+      # @params id [string] User ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] Returns an empty object.
+      # @see https://developer.okta.com/docs/api/resources/users#delete-user
+      # @example
+      #   Oktakit.delete_user('id')
+      def suspend_user(id, options = {})
+        delete("/users/#{id}", options)
+      end
+
       # Reset Password
       #
       # @params id [string] User ID


### PR DESCRIPTION
DELETE `/user/:id` is documented by Okta in their API documentation https://developer.okta.com/docs/reference/api/users/#delete-user

It would be useful as it would allow purging a user completely rather than just deactivating or suspending