### PR TITLE
Return response headers with data and status

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -172,7 +172,7 @@ module Oktakit
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
 
-      response = [resp.data, resp.status]
+      response = [resp.data, resp.status, resp.headers]
       response << absolute_to_relative_url(resp.rels[:next]) if paginate
       response
     end


### PR DESCRIPTION
In order to access information about rate limits and their expiries, the headers need to be returned alongside each response data and status code