### PR TITLE
Response object

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -66,7 +66,8 @@ module Oktakit
         data: options
       }
 
-      resp, next_page = request :get, url, **request_options
+      resp = request :get, url, **request_options
+      next_page = resp.rels[:next]
 
       # If request succeeded and we should paginate, then automatically traverse all next_pages
       if resp.status == 200 && should_paginate
@@ -80,7 +81,7 @@ module Oktakit
         resp = all_objs.flatten
       end
 
-      [resp]
+      resp
     end
 
     # Make a HTTP POST request
@@ -172,9 +173,10 @@ module Oktakit
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
 
-      response = [resp]
-      response << absolute_to_relative_url(resp.rels[:next]) if paginate
-      response
+      if paginate
+        resp.rels[:next] = absolute_to_relative_url(resp.rels[:next])
+      end
+      resp
     end
 
     def sawyer_agent

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -171,7 +171,10 @@ module Oktakit
 
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
-      resp
+
+      response = [resp.data, resp.status, resp.headers]
+      response << absolute_to_relative_url(resp.rels[:next]) if paginate
+      response
     end
 
     def sawyer_agent

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -66,21 +66,21 @@ module Oktakit
         data: options
       }
 
-      resp, status, next_page = request :get, url, **request_options
+      resp, next_page = request :get, url, **request_options
 
       # If request succeeded and we should paginate, then automatically traverse all next_pages
-      if status == 200 && should_paginate
+      if resp.status == 200 && should_paginate
         all_objs = [resp]
         while next_page
-          resp, status, next_page = request :get, next_page, **request_options
-          break unless status == 200 # Return early if page request fails
+          resp, resp.status, next_page = request :get, next_page, **request_options
+          break unless resp.status == 200 # Return early if page request fails
 
           all_objs << resp
         end
         resp = all_objs.flatten
       end
 
-      [resp, status]
+      [resp]
     end
 
     # Make a HTTP POST request
@@ -172,7 +172,7 @@ module Oktakit
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
 
-      response = [resp.data, resp.status, resp.headers]
+      response = [resp]
       response << absolute_to_relative_url(resp.rels[:next]) if paginate
       response
     end

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -54,7 +54,7 @@ module Oktakit
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options[:paginate] [Boolean] Optional. If true, will auto-paginate Okta's API responses.
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def get(url, options = {})
       should_paginate = options.delete(:paginate)
       request_options = {
@@ -92,7 +92,7 @@ module Oktakit
     # @param options[:accept] [String] Optional. The content type to accept. Default application/json
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def post(url, options = {})
       request :post, url, query: options.delete(:query), headers: options.delete(:headers),
                           accept: options.delete(:accept), content_type: options.delete(:content_type),
@@ -107,7 +107,7 @@ module Oktakit
     # @param options[:accept] [String] Optional. The content type to accept. Default application/json
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def put(url, options = {})
       request :put, url, query: options.delete(:query), headers: options.delete(:headers),
                          accept: options.delete(:accept), content_type: options.delete(:content_type),
@@ -122,7 +122,7 @@ module Oktakit
     # @param options[:accept] [String] Optional. The content type to accept. Default application/json
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def patch(url, options = {})
       request :patch, url, query: options.delete(:query), headers: options.delete(:headers),
                            accept: options.delete(:accept), content_type: options.delete(:content_type),
@@ -137,7 +137,7 @@ module Oktakit
     # @param options[:accept] [String] Optional. The content type to accept. Default application/json
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def delete(url, options = {})
       request :delete, url, query: options.delete(:query), headers: options.delete(:headers),
                             accept: options.delete(:accept), content_type: options.delete(:content_type),
@@ -152,7 +152,7 @@ module Oktakit
     # @param options[:accept] [String] Optional. The content type to accept. Default application/json
     # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
     # @param options [Hash] Optional. Body params for request.
-    # @return [Sawyer::Resource]
+    # @return Sawyer::Resource]
     def head(url, options = {})
       request :head, url, query: options.delete(:query), headers: options.delete(:headers),
                           accept: options.delete(:accept), content_type: options.delete(:content_type),

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -171,10 +171,7 @@ module Oktakit
 
       uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
-
-      response = [resp.data, resp.status, resp.headers]
-      response << absolute_to_relative_url(resp.rels[:next]) if paginate
-      response
+      resp
     end
 
     def sawyer_agent


### PR DESCRIPTION
Currently this gem returns an tuple of `(response text, status code)`, and only returns the headers if an error is encountered.

In order to keep an eye on the Okta rate limits, it's useful to be able to access the rate limit information returned in the response header, namely

```text
X-Rate-Limit-Limit - the rate limit ceiling that is applicable for the current request.
X-Rate-Limit-Remaining - the number of requests left for the current rate-limit window.
X-Rate-Limit-Reset - the time at which the rate limit will reset, specified in UTC epoch time.
```
reference: https://developer.okta.com/docs/reference/rate-limits/#check-your-rate-limits-with-okta-s-rate-limit-headers

---

Now the entire original Sawyer response object is returned, and the response details can be accessed via

```
response.data
response.status
response.headers
```