### PR TITLE
New version of Faraday needs non-private methods in the middleware

### DIFF
--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -7,7 +7,6 @@ module Oktakit
     # This class raises an Oktakit-flavored exception based
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
-      private
 
       def on_complete(response)
         if error = Oktakit::Error.from_response(response)


### PR DESCRIPTION
Emulating how faraday itself handles its own middleware for raising errors: https://github.com/lostisland/faraday/blob/main/lib/faraday/response/raise_error.rb

Note it's use of `respond_to?` when calling middleware: https://github.com/lostisland/faraday/blob/main/lib/faraday/middleware.rb#L19

```irb(main):001:0> class Bob
irb(main):002:1>   def whatever
irb(main):003:2>     puts "foo"
irb(main):004:2>   end
irb(main):005:1> end
=> :whatever
irb(main):006:0> Bob.new.respond_to?(:whatever)
=> true
irb(main):007:0> class Bilbob
irb(main):008:1>   private
irb(main):009:1>   def whatever
irb(main):010:2>     puts "foo"
irb(main):011:2>   end
irb(main):012:1> end
```
=> :whatever
irb(main):013:0> Bilbob.new.respond_to?(:whatever)
=> false